### PR TITLE
ILMerging logary - trying a few different options

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -4,6 +4,8 @@ require 'albacore'
 require 'albacore/tasks/versionizer'
 require 'albacore/ext/teamcity'
 
+load 'tools/pack.rb'
+
 Configuration = ENV['Configuration'] || 'Release'
 
 Albacore::Tasks::Versionizer.new :versioning
@@ -69,7 +71,7 @@ def maybe_sign conf
 end
 
 desc 'perform full build'
-build :build => [:versioning, :assembly_info, :restore] do |b|
+build :compile => [:versioning, :assembly_info, :restore] do |b|
   b.prop 'Configuration', Configuration
   b.sln = 'src/Logary.sln'
   maybe_sign b
@@ -96,7 +98,7 @@ nugets_pack :nugets_quick => :versioning do |p|
 end
 
 desc 'package nugets - finds all projects and package them'
-task :nugets => ['build/pkg', :versioning, :build, :nugets_quick]
+task :nugets => ['build/pkg', :versioning, :compile, :nugets_quick]
 
 task :tests_unit do
   Dir.glob("src/*.Tests/bin/#{Configuration}/*.Tests.exe").
@@ -125,7 +127,7 @@ task :nugets_push do
 end
 
 desc 'run unit tests'
-task :tests => [:build, :tests_unit]
+task :tests => [:compile, :tests_unit]
 
 task :default => [:tests, :nugets]
 

--- a/tools/pack.rb
+++ b/tools/pack.rb
@@ -23,7 +23,8 @@ end
 def install_nuget name
   unless Dir.exist? "tools/#{name}"
     system 'tools/NuGet.exe',
-           %W|install -ExcludeVersion -OutputDirectory tools #{name}|
+           %W|install -ExcludeVersion -OutputDirectory tools #{name}|,
+           clr_command: true
   end
 end
 

--- a/tools/pack.rb
+++ b/tools/pack.rb
@@ -2,24 +2,6 @@ require 'albacore'
 require 'albacore/project'
 require 'albacore/paths'
 
-# reference: 
-# https://github.com/EventStore/EventStore/blob/dev/scripts/package-mono/package-mono.sh
-
-def mkbundle bin, configuration = 'Release'
-  fail 'on Windows, use another tool, e.g. ' if Albacore.windows?
-  fail 'invalid "bin" parameter' unless bin
-  material = Dir[Paths.join(bin, '*.{dll,config}')]
-  mono_config = 'TODO'
-  machine_config = 'TODO'
-  # this doesn't help me much since I'm not merging into an executable
-  system 'mkbundle',
-       %w|-o -oo logary.a|.concat(material).concat(
-         %W|--static --deps --config #{monoconfig} --machine-config #{machineconfig}|
-       )
-  system 'cc',
-       %W|-o logary #{ES_COMPILE_FLAGS} testclient.c testclient.a $MONOPREFIX/lib/libmonosgen-2.0.a $MONOPREFIX/lib/libMonoPosixHelper.a|
-end
-
 def install_nuget name
   unless Dir.exist? "tools/#{name}"
     system 'tools/NuGet.exe',
@@ -28,26 +10,37 @@ def install_nuget name
   end
 end
 
-def pack tool = 'tools/ILRepack/tools/ILRepack.exe'
-         dir = 'src/Logary/bin/Release'
-  files = %w|FSharp.Actor FSharp.Core Intelliplan.JsonNet.NodaTime
-             Intelliplan.JsonNet Newtonsoft.Json NodaTime
-             policy.2.3.FSharp.Core|.
-          map { |f| "#{dir}/#{f}.dll" }
+def pack files,
+         tool = 'tools/ilmerge/ILMerge.exe',
+         deps = %w(ilmerge)
 
   system tool,
-         %W|--keyfile:src/signing/LogaryPublic.snk --ver:#{ENV['FORMAL_VERSION']}
-            --xmldocs --internalize --parallel --index --verbose
-            --targetplatform:v4
-            --out:Logary.dll
-            --lib:tools/IKVM/lib|.
+    %W|/keyfile:src/signing/LogaryPublic.snk
+       /ver:#{ENV['FORMAL_VERSION'] || '1.2.3'}
+       /xmldocs /internalize
+       /targetplatform:v4
+       /out:build/Intelliplan.Logary-unit/Logary.dll
+       src/Logary/bin/Release/Logary.dll|.
          concat(files),
          clr_command: true
+
+  FileUtils.cp 'src/Logary/bin/Release/Logary.dll.config', 'build/Intelliplan.Logary-unit/Logary.dll.config'
 end
 
-desc 'pack the release of Logary with ILRepack'
-task :pack do
-  install_nuget 'IKVM'
-  install_nuget 'ILRepack'
-  pack
+directory 'build/Intelliplan.Logary-unit'
+
+task :pack_logary_quick => 'build/Intelliplan.Logary-unit' do
+  # ilpack_deps = %w(IKVM ILRepack)
+  proj = Albacore::Project.new 'src/Logary/Intelliplan.Logary.fsproj'
+
+  out = Paths.join('src/Logary', proj.output_path('Release')).to_s
+  files =["src/Logary/bin/Release/FSharp.Actor.dll", "src/Logary/bin/Release/FSharp.Core.dll", "src/Logary/bin/Release/Intelliplan.JsonNet.NodaTime.dll", "src/Logary/bin/Release/Intelliplan.JsonNet.dll", "src/Logary/bin/Release/Newtonsoft.Json.dll", "src/Logary/bin/Release/NodaTime.dll", "src/Logary/bin/Release/policy.2.3.FSharp.Core.dll"]
+
+  debug { "going to pack files: #{files.inspect}" }
+
+  pack files
+  pkg = Albacore::NugetModel::Package.new nil, files
 end
+
+desc 'pack the release of Logary with ilmerge'
+task :pack_logary => [:compile]

--- a/tools/pack.rb
+++ b/tools/pack.rb
@@ -1,0 +1,52 @@
+require 'albacore'
+require 'albacore/project'
+require 'albacore/paths'
+
+# reference: 
+# https://github.com/EventStore/EventStore/blob/dev/scripts/package-mono/package-mono.sh
+
+def mkbundle bin, configuration = 'Release'
+  fail 'on Windows, use another tool, e.g. ' if Albacore.windows?
+  fail 'invalid "bin" parameter' unless bin
+  material = Dir[Paths.join(bin, '*.{dll,config}')]
+  mono_config = 'TODO'
+  machine_config = 'TODO'
+  # this doesn't help me much since I'm not merging into an executable
+  system 'mkbundle',
+       %w|-o -oo logary.a|.concat(material).concat(
+         %W|--static --deps --config #{monoconfig} --machine-config #{machineconfig}|
+       )
+  system 'cc',
+       %W|-o logary #{ES_COMPILE_FLAGS} testclient.c testclient.a $MONOPREFIX/lib/libmonosgen-2.0.a $MONOPREFIX/lib/libMonoPosixHelper.a|
+end
+
+def install_nuget name
+  unless Dir.exist? "tools/#{name}"
+    system 'tools/NuGet.exe',
+           %W|install -ExcludeVersion -OutputDirectory tools #{name}|
+  end
+end
+
+def pack tool = 'tools/ILRepack/tools/ILRepack.exe'
+         dir = 'src/Logary/bin/Release'
+  files = %w|FSharp.Actor FSharp.Core Intelliplan.JsonNet.NodaTime
+             Intelliplan.JsonNet Newtonsoft.Json NodaTime
+             policy.2.3.FSharp.Core|.
+          map { |f| "#{dir}/#{f}.dll" }
+
+  system tool,
+         %W|--keyfile:src/signing/LogaryPublic.snk --ver:#{ENV['FORMAL_VERSION']}
+            --xmldocs --internalize --parallel --index --verbose
+            --targetplatform:v4
+            --out:Logary.dll
+            --lib:tools/IKVM/lib|.
+         concat(files),
+         clr_command: true
+end
+
+desc 'pack the release of Logary with ILRepack'
+task :pack do
+  install_nuget 'IKVM'
+  install_nuget 'ILRepack'
+  pack
+end


### PR DESCRIPTION
See:

 1. ILRepack cecil bug - https://github.com/gluck/il-repack/issues/65
 1. ILRepack mono bug - https://github.com/gluck/il-repack/issues/68
 1. Thread prompting this PR - https://github.com/EventStore/EventStore/issues/255
 1. Corresponding logary github issue - https://github.com/logary/logary/issues/49

Rationale: sometimes is can be hard, and other times it can be impossible, to properly manage frequently-used library references when your code-base grows and you get more and more users.

As a part of getting logary more widely adopted, I want to cut back on the number of dependencies the project is forced to take. Hence this work.