### PR TITLE
Changes message check to null to match exception thrown in LoggerExtensions.

### DIFF
--- a/src/Logary/LoggerExtensions.fs
+++ b/src/Logary/LoggerExtensions.fs
@@ -14,7 +14,7 @@ module LoggerExtensions =
   let log (logger : Logger, message, level, data, tags, path,
            ``exception``,
            timestamp : Nullable<NodaTime.Instant>) =
-    if String.IsNullOrWhiteSpace message then nullArg "message"
+    if message == null then nullArg "message"
     { message       = message
       level         = level
       data          = Map.fromObj data
@@ -27,7 +27,7 @@ module LoggerExtensions =
   /// Log a message with some accompanying data to the log
   [<Extension; CompiledName("Log")>]
   let logAnnotate (logger : Logger, message, level, data) =
-    if String.IsNullOrWhiteSpace message then nullArg "message"
+    if message == null then nullArg "message"
     { message       = message
       level         = level
       data          = Map.fromObj data


### PR DESCRIPTION
The check in LoggerExtensions for message is String IsNullOrWhitespace, but the exception thrown is NullArgument, I have changed the check to null equality to match that of the .net LoggerExtensions.