### PR TITLE
Add static factory method to enhance the C# facade.

### DIFF
--- a/src/Logary/Formatting.fs
+++ b/src/Logary/Formatting.fs
@@ -94,6 +94,11 @@ type StringFormatter =
     { format   = format'
       m_format = LogLine.fromMeasure >> format' }
 
+  /// Takes c# Func delegates to initialise a StringFormatter
+  static member Create (format:Func<LogLine, string>, m_format:Func<Measure, string>) = 
+    { format = fun x -> format.Invoke x
+      m_format= fun m -> m_format.Invoke m }
+
   /// Verbatim simply outputs the message and no other information
   /// and doesn't append a newline to the string.
   static member Verbatim =

--- a/src/Logary/Formatting.fs
+++ b/src/Logary/Formatting.fs
@@ -99,6 +99,11 @@ type StringFormatter =
     { format = fun x -> format.Invoke x
       m_format= fun m -> m_format.Invoke m }
 
+  /// Takes a c# Func delegate to initialise a StringFormatter with the default Measure -> string
+  static member Create (format:Func<LogLine, string>) = 
+    { format = fun x -> format.Invoke x
+      m_format= Measure.getValueStr }
+
   /// Verbatim simply outputs the message and no other information
   /// and doesn't append a newline to the string.
   static member Verbatim =


### PR DESCRIPTION
To avoid having to specify the formatter like this: 

```c#

new Logary.Formatting.StringFormatter(FSharpFunc<LogLine, string>.FromConverter(
    input =>
        String.Format("{0} {1} : {2}, {3} {4}", input.timestamp, input.path,
                input.level, input.message,
                input.exception)),
            FSharpFunc<Measure, string>.FromConverter(m => m.ToString()))
```

I added a `Create` method to the `StringFormatter` that will make this look a bit better.