### PR TITLE
Incorrect syntax by first run

### DIFF
--- a/src/targets/Logary.Targets.DB.Migrations/Migrations.fs
+++ b/src/targets/Logary.Targets.DB.Migrations/Migrations.fs
@@ -17,7 +17,7 @@ type MetricsTable() =
       .WithColumn("Host").AsString(255).NotNullable()
         .WithColumnDescription("Hostname/DNS name of sender")
       .WithColumn("Path").AsString(255).NotNullable().WithDefaultValue(String.Empty)
-        .WithColumnDescription("Where''s the metric taken from; see graphite type paths")
+        .WithColumnDescription("Where is the metric taken from; see graphite type paths")
       .WithColumn("EpochTicks").AsInt64()
         .WithColumnDescription("No. of ticks since Unix Epoch. 1 tick = 100 ns = 10 000 ms")
       .WithColumn("Level").AsInt16().NotNullable()


### PR DESCRIPTION
In the table initialization the description this [string](https://github.com/logary/logary/blob/9057f8be5c64f4af81515d6d22a42a054c5200b3/src/targets/Logary.Targets.DB.Migrations/Migrations.fs#L20) causes an exception:

    ....
    .WithColumnDescription("Where's the metric taken from; see graphite type paths")
    ....                         ^

Incorrect syntax bug:
> Error 102: Incorrect syntax near 's'.
> Unclosed quotation mark after the character string ''.

First thought it is a plain string as used in later sql statement. Now seems to be a Fluentmigrator bug. Therefore quick fix for now.