### PR TITLE
Allow named fields in `eventFormat` templates 

### DIFF
--- a/src/Logary/DataModel.fs
+++ b/src/Logary/DataModel.fs
@@ -1163,15 +1163,11 @@ module Message =
   /// A destructuring strategy for FsMessageTemplates which simply treats 
   /// everything as a 'Scalar' object which can later be handled by Logary
   /// as `Field (Value.ofObject o, None)`
-  let internal destructureEverythingAsScalarObject : Destructurer =
+  let internal destructureAllAsScalar : Destructurer =
     fun request -> TemplatePropertyValue.ScalarValue request.Value
   
   let internal captureNamesAndValuesAsScalars (t: Template) (args: obj[]) = 
-    let selfLogByIgnoring : SelfLogger = fun (t, v) -> ()
-    Capturing.capturePropertiesWith
-      selfLogByIgnoring
-      destructureEverythingAsScalarObject
-      1 t args
+    Capturing.capturePropertiesWith ignore destructureAllAsScalar 1 t args
 
   let internal convertToNameAndField (pnv : PropertyNameAndValue) : string * Field =
     match pnv.Value with
@@ -1182,26 +1178,9 @@ module Message =
   /// a message template and a set of fields.
   let internal templateFromFormat (format : string) (args : obj[]) =
     let parsedTemplate = Parser.parse format
-    let isPositional = parsedTemplate.Positionals <> Unchecked.defaultof<PropertyToken[]>
-    let positionalFixedTemplate =
-      if isPositional then
-        // if the properties are all positional {0}, {1}..{N} then convert them {arg0}, {arg1}..{argN}
-        let collectedProps = ResizeArray<PropertyToken>(parsedTemplate.Positionals.Length)
-        let prependArgName (pt : PropertyToken) =
-          let p = PropertyToken("arg" + pt.Name, pt.Pos, pt.Destr, pt.Align, pt.Format)
-          collectedProps.Add(p)
-          p
-
-        let tokenOrPrependArgNameProp t = match t with Text _ as tt -> tt | Prop (start, pt) -> Prop(start, prependArgName pt)
-        let tokensWithArgNameInProps = parsedTemplate.Tokens |> Seq.map tokenOrPrependArgNameProp |> Array.ofSeq
-        let newFormatString = String.Join("", tokensWithArgNameInProps |> Array.map string)
-        Template(newFormatString, tokensWithArgNameInProps, isNamed = false, properties = collectedProps.ToArray())
-      else
-        parsedTemplate
-
-    let scalarNamesAndValues = captureNamesAndValuesAsScalars positionalFixedTemplate args
-    let fields = scalarNamesAndValues |> Seq.map convertToNameAndField |> List.ofSeq
-    (positionalFixedTemplate.FormatString, fields)
+    let scalarNamesAndValues = captureNamesAndValuesAsScalars parsedTemplate args
+    let fields = scalarNamesAndValues |> Seq.map (convertToNameAndField) |> List.ofSeq
+    (format, fields)
 
   /// Creates a new event with given level, format and arguments. Format may
   /// contain String.Format-esque format placeholders.

--- a/src/Logary/DataModel.fs
+++ b/src/Logary/DataModel.fs
@@ -1158,19 +1158,33 @@ module Message =
   [<CompiledName "EventFatalFormat">]
   let eventFatalf fmt = Printf.kprintf (event LogLevel.Fatal) fmt
 
+  open Logary.Utils.FsMessageTemplates
+
+  /// A destructuring strategy for FsMessageTemplates which simply treats 
+  /// everything as a 'Scalar' object which can later be handled by Logary
+  /// as `Field (Value.ofObject o, None)`
+  let internal destructureEverythingAsScalarObject : Destructurer =
+    fun request -> TemplatePropertyValue.ScalarValue request.Value
+  
+  let internal captureNamesAndValuesAsScalars (t: Template) (args: obj[]) = 
+    let selfLogByIgnoring : SelfLogger = fun (t, v) -> ()
+    Capturing.capturePropertiesWith
+      selfLogByIgnoring
+      destructureEverythingAsScalarObject
+      1 t args
+
+  let internal convertToNameAndField (pnv : PropertyNameAndValue) : string * Field =
+    match pnv.Value with
+    | ScalarValue v -> pnv.Name, Field (Value.ofObject v, None)
+    | _ -> failwith "This should never happen. In Logary we extract all properties as Scalar"
+
   /// Converts a String.Format-style format string and an array of arguments into
   /// a message template and a set of fields.
   let internal templateFromFormat (format : string) (args : obj[]) =
-    let fields =
-      args
-      |> Array.mapi (fun i v ->
-        sprintf "arg%i" i,
-        Field (Value.ofObject v, None))
-      |> List.ofArray
-
-    // Replace {0}..{n} with {arg0}..{argn}
-    let template = Seq.fold (fun acc i -> String.replace (sprintf "{%i}" i) (sprintf "{arg%i}" i) acc) format [0..args.Length]
-    (template, fields)
+    let parsedTemplate = Parser.parse format
+    let scalarNamesAndValues = captureNamesAndValuesAsScalars parsedTemplate args
+    let fields = scalarNamesAndValues |> Seq.map convertToNameAndField |> List.ofSeq
+    (format, fields)
 
   /// Creates a new event with given level, format and arguments. Format may
   /// contain String.Format-esque format placeholders.

--- a/src/tests/Logary.Tests/Formatting.fs
+++ b/src/tests/Logary.Tests/Formatting.fs
@@ -152,7 +152,7 @@ let tests =
       let args : obj[] = [|0;1;2;3|] 
       (because "fields are matched positionally when all are numbered" <| fun () ->
         Message.templateFromFormat format args)
-      |> should equal ("This {2} . {2} . {0} . {0}",
+      |> should equal ("Positionally - two {2} . {2} . zero {0} . {0}",
                        [ ("0", Field (Int64 0L, None))
                          ("2", Field (Int64 2L, None)) ])
       |> thatsIt

--- a/src/tests/Logary.Tests/Formatting.fs
+++ b/src/tests/Logary.Tests/Formatting.fs
@@ -136,4 +136,14 @@ let tests =
                          "arg1", Field (Int64 4L, None) ])
       |> thatsIt
 
+    testCase "Formatting.templateFromFormat, named fields" <| fun _ ->
+      let format = "This {gramaticalStructure} contains {wordCount} words."
+      let args : obj[] = [|"sentence"; 4|]
+      (because "fields are matched left-to-right in message template" <| fun () ->
+        Message.templateFromFormat format args)
+      |> should equal ("This {gramaticalStructure} contains {wordCount} words.",
+                       [ "gramaticalStructure", Field (String "sentence", None)
+                         "wordCount", Field (Int64 4L, None) ])
+      |> thatsIt
+
     ]

--- a/src/tests/Logary.Tests/Formatting.fs
+++ b/src/tests/Logary.Tests/Formatting.fs
@@ -131,9 +131,30 @@ let tests =
       let args : obj[] = [|"sentence"; 4|]
       (because "converting a String.Format into a message template" <| fun () ->
         Message.templateFromFormat format args)
-      |> should equal ("This {arg0} contains {arg1} words.",
-                       [ "arg0", Field (String "sentence", None)
-                         "arg1", Field (Int64 4L, None) ])
+      |> should equal ("This {0} contains {1} words.",
+                       [ "0", Field (String "sentence", None)
+                         "1", Field (Int64 4L, None) ])
+      |> thatsIt
+      
+    testCase "Formatting.templateFromFormat, named and positional fields" <| fun _ ->
+      let format = "This {gramaticalStructure} contains {wordCount} {0}."
+      let args : obj[] = [|"sentence"; 4; "words"|]
+      (because "fields are matched left-to-right when any fields are named" <| fun () ->
+        Message.templateFromFormat format args)
+      |> should equal ("This {gramaticalStructure} contains {wordCount} {0}.",
+                       [ "gramaticalStructure", Field (String "sentence", None)
+                         "wordCount", Field (Int64 4L, None)
+                         "0", Field (String "words", None) ])
+      |> thatsIt
+
+    testCase "Formatting.templateFromFormat, positional fields" <| fun _ ->
+      let format = "Positionally - two {2} . {2} . zero {0} . {0}"
+      let args : obj[] = [|0;1;2;3|] 
+      (because "fields are matched positionally when all are numbered" <| fun () ->
+        Message.templateFromFormat format args)
+      |> should equal ("This {2} . {2} . {0} . {0}",
+                       [ ("0", Field (Int64 0L, None))
+                         ("2", Field (Int64 2L, None)) ])
       |> thatsIt
 
     testCase "Formatting.templateFromFormat, named fields" <| fun _ ->


### PR DESCRIPTION

The goal is to allow [`eventFormat`](https://github.com/logary/logary/blob/f5c3e31fcf96678a7b02db8f59c365893cfcbc6d/src/Logary/DataModel.fs#L1178) to accept log messages like:

```fsharp
testCase "Formatting.templateFromFormat, named fields" <| fun _ ->
    let format = "This {gramaticalStructure} contains {wordCount} words."
    let args : obj[] = [|"sentence"; 4|]
    (because "fields are matched left-to-right in message template" <| fun () ->
        Message.templateFromFormat format args)
    |> should equal ("This {gramaticalStructure} contains {wordCount} words.",
                        [ "gramaticalStructure", Field (String "sentence", None)
                        "wordCount", Field (Int64 4L, None) ])
    |> thatsIt
```