### PR TITLE
[DataModel] reluctantly un-internalising Message.templateFromFormat

### DIFF
--- a/src/Logary/AssemblyInfo.fs
+++ b/src/Logary/AssemblyInfo.fs
@@ -1,6 +1,5 @@
 namespace Logary
 open System.Reflection
 open System.Runtime.CompilerServices
-[<assembly: InternalsVisibleTo("Logary.Tests")>]
 [<assembly: InternalsVisibleTo("Logary.CSharp")>]
 ()

--- a/src/Logary/Configuration_Uri.fs
+++ b/src/Logary/Configuration_Uri.fs
@@ -58,7 +58,7 @@ module Uri =
       Some (fun (s : string) ->
         m.Invoke(null, [| s |]) |> unbox : Choice<obj, string>)
 
-  let internal convertTo typ (v : string) : obj =
+  let convertTo typ (v : string) : obj =
     match conversion.TryGetValue typ with
     | false, _ ->
       match tryGetTryParse typ with

--- a/src/Logary/DataModel.fs
+++ b/src/Logary/DataModel.fs
@@ -853,6 +853,21 @@ module Field =
   let inline init (value : ^a) =
     Field (Value.serialize value, None)
 
+  /// Converts a String.Format-style format string and an array of arguments into
+  /// a message template and a set of fields.
+  let templateFromFormat (format : string) (args : obj[]) =
+    let fields =
+      args
+      |> Array.mapi (fun i v ->
+        sprintf "arg%i" i,
+        Field (Value.ofObject v, None))
+      |> List.ofArray
+
+    // Replace {0}..{n} with {arg0}..{argn}
+    let template = Seq.fold (fun acc i -> String.replace (sprintf "{%i}" i) (sprintf "{arg%i}" i) acc) format [0..args.Length]
+    (template, fields)
+
+
 /// This is the main value type of Logary. It spans both logging and metrics.
 type Message =
   { /// The 'path' or 'name' of this data point. Do not confuse template in
@@ -1176,7 +1191,7 @@ module Message =
 
   /// Converts a String.Format-style format string and an array of arguments into
   /// a message template and a set of fields.
-  let internal templateFromFormat (format : string) (args : obj[]) =
+  let templateFromFormat (format : string) (args : obj[]) =
     let parsedTemplate = Parser.parse format
     let scalarNamesAndValues = captureNamesAndValuesAsScalars parsedTemplate args
     let fields = scalarNamesAndValues |> Seq.map (convertToNameAndField) |> List.ofSeq
@@ -1186,7 +1201,7 @@ module Message =
   /// contain String.Format-esque format placeholders.
   [<CompiledName "EventFormat">]
   let eventFormat (level, format, [<ParamArray>] args : obj[]) =
-    let (template, fields) = templateFromFormat format args
+    let (template, fields) = Field.templateFromFormat format args
     event level template |> setFieldValues fields
 
   /// Run the function `f` and measure how long it takes; logging that

--- a/src/Logary/Targets_Graphite.fs
+++ b/src/Logary/Targets_Graphite.fs
@@ -30,7 +30,7 @@ type GraphiteConf =
     { hostname = hostname
       port     = port }
 
-module internal Impl =
+module Impl =
 
   type GraphiteState =
     { client         : TcpClient

--- a/src/tests/Logary.Tests/Logary.Tests.fsproj
+++ b/src/tests/Logary.Tests/Logary.Tests.fsproj
@@ -34,6 +34,10 @@
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets" />
   <ItemGroup>
+    <Compile Include="..\..\..\paket-files\haf\YoLo\YoLo.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/YoLo.fs</Link>
+    </Compile>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/tests/Logary.Tests/paket.references
+++ b/src/tests/Logary.Tests/paket.references
@@ -6,3 +6,4 @@ Fuchu
 Fuchu.FsCheck
 Unquote
 File:Assert.fs
+File:YoLo.fs


### PR DESCRIPTION
When strongnaming we must strongname the Test assembly if we have InternalsVisibleTo in Logary to Test. 

This is a cherry pick from the strong-naming branch