### PR TITLE
Don't crash when a template field is missing,

### DIFF
--- a/src/Logary/Formatting.fs
+++ b/src/Logary/Formatting.fs
@@ -27,13 +27,15 @@ module MessageParts =
         t
 
       | Prop (_, p) ->
-        let (Field (value, units)) = Map.find (PointName.ofSingle p.Name) args
-        match units with
-        | Some units ->
-          Units.formatWithUnit Units.Suffix (units) value
-
-        | None ->
-          Units.formatValue value)
+        match Map.tryFind (PointName.ofSingle p.Name) args with
+        | Some (Field (value, units)) -> 
+            match units with
+            | Some units ->
+              Units.formatWithUnit Units.Suffix (units) value
+            | None ->
+              Units.formatValue value
+        | None -> p.ToString()
+        )
     |> Seq.iter (append sb)
     sb.ToString()
 


### PR DESCRIPTION
instead, we just render the property token.

Before this change, doing this:
```fsharp
Message.event Info "User {userName} logged in"
|> Logger.logSimple logger 
```

results in an exception like this:
```
E 2016-08-02T12:36:21.9001391+00:00: Job "console" has crashed and will be restarted. [Logary.Supervisor]
  errors =>
    -
      hResult => -2146232969
      message => "The given key was not present in the dictionary."
      source => "FSharp.Core"
      stackTrace => "   at Microsoft.FSharp.Collections.MapTreeModule.find[TValue,a](IComparer`1 comparer, TValue k, MapTree`2 m)
   at Microsoft.FSharp.Collections.MapModule.Find[TKey,T](TKey key, FSharpMap`2 table)
   at Logary.Formatting.MessageParts.formatTemplate@25.Invoke(Token _arg1) in C:\My\repo\logary\src\Logary\Formatting.fs:line 30
   at Microsoft.FSharp.Collections.IEnumerator.map@111.DoMoveNext(b& )
   at Microsoft.FSharp.Collections.IEnumerator.MapEnumerator`1.System-Collections-IEnumerator-MoveNext()
   at Microsoft.FSharp.Collections.SeqModule.Iterate[T](FSharpFunc`2 action, IEnumerable`1 source)
   at Logary.Formatting.MessageParts.formatTemplate(String template, FSharpMap`2 args) in C:\My\repo\logary\src\Logary\Formatting.fs:line 24
   at Logary.Formatting.MessageParts.formatValueShallow(Message msg) in C:\My\repo\logary\src\Logary\Formatting.fs:line 43
   at Logary.Formatting.StringFormatterModule.expanded@127.Logary-Formatting-StringFormatter-format(Message ) in C:\My\repo\logary\src\Logary\Formatting.fs:line 132
   at Logary.Targets.TextWriter.Impl.loop@60-20.Invoke(Unit unitVar) in C:\My\repo\logary\src\Logary\Targets_Core.fs:line 61
   at Logary.Targets.TextWriter.Impl.loop@59-33.Do() in C:\My\repo\logary\src\Logary\Targets_Core.fs:line 59
   at Hopac.Core.JobDelay`1.DoJob(Worker& wr, Cont`1 xK)
   at Hopac.Core.AltAfterJob`2.ContAfterJob.DoCont(Worker& wr, X x)
   at Hopac.Ch`1.TryAlt(Worker& wr, Int32 i, Cont`1 xK, Else xE)
   at Hopac.Core.AltAfterJob`2.TryAlt(Worker& wr, Int32 i, Cont`1 yK, Else yE)
   at Hopac.Alt.choose@497-1.TryElse(Worker& wr, Int32 i)
   at Hopac.Ch`1.TryAlt(Worker& wr, Int32 i, Cont`1 xK, Else xE)
   at Hopac.Core.AltAfterJob`2.TryAlt(Worker& wr, Int32 i, Cont`1 yK, Else yE)
   at Hopac.Alt.choose@492.DoJob(Worker& wr, Cont`1 aK)
   at Hopac.Core.JobBind`2.ContBind.DoWork(Worker& wr)
   at Hopac.IVar`1.Fill.DoJob(Worker& wr, Cont`1 uK)
   at Hopac.Core.JobBind`2.DoJob(Worker& wr, Cont`1 yK)
   at Hopac.Core.JobDelay`1.DoJob(Worker& wr, Cont`1 xK)
   at Hopac.Util.SeqCont`2.DoWork(Worker& wr)
   at Hopac.Core.AlwaysUnitNonTC.DoJob(Worker& wr, Cont`1 uK)
   at Hopac.Infixes.op_GreaterGreaterEqualsDot@197.DoJob(Worker& wr, Cont`1 aK)
   at Hopac.Core.JobBind`2.ContBind.DoWork(Worker& wr)
   at Hopac.Core.TaskToJob.DoJob(Worker& wr, Cont`1 uK)
   at Hopac.Core.JobBind`2.DoJob(Worker& wr, Cont`1 yK)
   at Hopac.Core.JobDelay`1.DoJob(Worker& wr, Cont`1 xK)
   at Hopac.Core.AltAfterJob`2.ContAfterJob.DoCont(Worker& wr, X x)
   at Hopac.Core.Taker`1.DoWork(Worker& wr)
   at Hopac.Core.Worker.Run(Scheduler sr, Int32 me)"
      targetSite => "a find[TValue,a](System.Collections.Generic.IComparer`1[TValue], TValue, Microsoft.FSharp.Collections.MapTree`2[TValue,a])"
      type => “System.Collections.Generic.KeyNotFoundException"
```