### PR TITLE
[infra] Add timeout to logSimple

### DIFF
--- a/src/Logary/Logger.fs
+++ b/src/Logary/Logger.fs
@@ -87,7 +87,11 @@ module Logger =
   /// instead start the Alt on the Hopac scheduler.
   [<CompiledName "LogSimple"; Extension>]
   let logSimple (logger : Logger) msg : unit =
-    log logger msg |> start
+    Alt.choose [
+      log logger msg
+      timeOutMillis 5000
+    ]
+    |> start
 
   [<CompiledName "LogWithAck"; Extension>]
   let logWithAck (logger : Logger) msg : Alt<Promise<unit>> =


### PR DESCRIPTION
...to avoid unbounded buffer issues through Hopac's scheduler. /cc @polytypic

The idea is that unless you add a timeout case then a completely non-draining RingBuffer will cause all start-ed jobs to be queued on the scheduler, awaiting drainage.