### PR TITLE
Simplifiy `setField`

### DIFF
--- a/src/Logary.Facade/Facade.fs
+++ b/src/Logary.Facade/Facade.fs
@@ -524,15 +524,7 @@ module Message =
 
   /// Sets the value of the field on the log message.
   let setField (key : string) (value : obj) (x : Message) =
-    let put k v m =
-      match m |> Map.tryFind k with
-      | None ->
-        m |> Map.add k v
-
-      | Some _ ->
-        m |> Map.remove k |> Map.add k v
-
-    { x with fields = x.fields |> put key value }
+    { x with fields = x.fields |> Map.add key value }
 
   /// Alias to `setField`
   let setFieldValue = setField


### PR DESCRIPTION
Removes another instance of a `Map.remove k |> Map.add k v` chain. Additionally simplifies out `put` since `Map.add` handles that case appropriately.