### PR TITLE
Allow dotted names in message templates

### DIFF
--- a/src/Logary/MessageTemplates.fs
+++ b/src/Logary/MessageTemplates.fs
@@ -157,7 +157,7 @@ module Parser =
         else startAt, Empty.textToken
 
     let inline isLetterOrDigit c = System.Char.IsLetterOrDigit c
-    let inline isValidInPropName c = c = '_' || System.Char.IsLetterOrDigit c
+    let inline isValidInPropName c = c = '_' || c = '.' || System.Char.IsLetterOrDigit c
     let inline isValidInDestrHint c = c = '@' || c = '$'
     let inline isValidInAlignment c = c = '-' || System.Char.IsDigit c
     let inline isValidInFormat c = c <> '}' && (c = ' ' || isLetterOrDigit c || System.Char.IsPunctuation c)

--- a/src/tests/Logary.Tests/Formatting.fs
+++ b/src/tests/Logary.Tests/Formatting.fs
@@ -181,6 +181,16 @@ let tests =
                              "wordCount", Field (Int64 4L, None) ])
       |> thatsIt
 
+    testCase "Formatting.templateFormat, named fields with '.'" <| fun _ ->
+      let format = "This {gramatical.structure} contains {wordCount} words."
+      let args : obj[] = [|"sentence"; 4|]
+      (because "fields are matched left-to-right in message template" <| fun () ->
+        extractFormatFields (Message.templateFormat format args))
+      |> should equal ("This {gramatical.structure} contains {wordCount} words.",
+                       Set [ "gramatical.structure", Field (String "sentence", None)
+                             "wordCount", Field (Int64 4L, None) ])
+      |> thatsIt
+
     testCase "Formatting.templateFormat, named fields, missing last" <| fun _ ->
       let format = "This {gramaticalStructure} contains {wordCount} words."
       let args : obj[] = [|"sentence"|]


### PR DESCRIPTION
Fields in a log message may use dotted names. This allows the template engine to access those names.

Possible future changes may include using dots to reach into fields with object values to access child items.
