### PR TITLE
Fix level required to log for `logDebug`

### DIFF
--- a/src/Logary/Logger.fs
+++ b/src/Logary/Logger.fs
@@ -113,7 +113,7 @@ module Logger =
   /// accepts line with Debug level.
   [<CompiledName "LogDebug"; Extension>]
   let logDebug (logger : Logger) fMessage =
-    ifLevel logger Verbose (Alt.always ()) <| fun _ ->
+    ifLevel logger Debug (Alt.always ()) <| fun _ ->
       logger.logDebugWithAck (fMessage >> ensureName logger)
       |> Alt.afterFun ignore
 


### PR DESCRIPTION
`logDebug` was requiring that a target accept logging at the `Verbose` level in order to forward messages.

For `fMessage`s that were consuming the `LogLevel` passed in, they were also being incorrectly set with the `Verbose` log level.