### PR TITLE
Upgrade FsMessageTemplates and mark internal

### DIFF
--- a/src/Logary/Formatting.fs
+++ b/src/Logary/Formatting.fs
@@ -23,10 +23,10 @@ module MessageParts =
 
     template.Tokens
     |> Seq.map (function
-      | Text (_, t) ->
+      | TextToken (_, t) ->
         t
 
-      | Prop (_, p) ->
+      | PropToken (_, p) ->
         match Map.tryFind (PointName.ofSingle p.Name) args with
         | Some (Field (value, units)) -> 
             match units with


### PR DESCRIPTION
The biggest impact with this PR is that I've marked FsMessageTemplates as internal. 

The main changes in FsMessageTemplates are:

 * Support for `ICustomFormatter` (does not impact Logary, because Logary doesn't use FsMessageTemplates formatting)
 * `Token.Text|Prop` --> `Token.TextToken|PropToken`
 * `PropertyToken` --> `Property`
 * reworked `findNextNonPropText` which allows a similar usage provided by the cut-down Facade parser (where the caller provides callbacks for `foundProperty` and `foundText`)
 * Ability to reflect over fsharp types (does not impact Logary, since Logary currently implements it's own data model for capturing logged properties).

from https://github.com/messagetemplates/messagetemplates-fsharp/blob/78a7c2ade80cccd6ebdffacf03393bdd68f622b8/src/FsMessageTemplates/MessageTemplates.fs