### PR TITLE
Less new lines in literate exception rendering

### DIFF
--- a/src/Logary.Facade/Facade.fs
+++ b/src/Logary.Facade/Facade.fs
@@ -511,7 +511,6 @@ module internal Formatting =
       match message.fields.TryFind FieldExnKey with
       | Some (:? Exception as ex) ->
         literateExceptionColouriser context ex
-        @ [ Environment.NewLine, Text ]
       | _ ->
         [] // there is no spoon
     let errorsExceptionParts =
@@ -520,7 +519,6 @@ module internal Formatting =
         exnListAsObjList |> List.collect (function
           | :? exn as ex ->
             literateExceptionColouriser context ex
-            @ [ Environment.NewLine, Text ]
           | _ ->
             [])
       | _ ->
@@ -543,7 +541,6 @@ module internal Formatting =
       if not exnParts.IsEmpty then
         [ Environment.NewLine, Text ]
         @ exnParts
-        @ [ Environment.NewLine, Text ]
       else []
 
     let getLogLevelToken = function

--- a/src/Logary.Facade/Facade.fs
+++ b/src/Logary.Facade/Facade.fs
@@ -500,10 +500,12 @@ module internal Formatting =
       | line ->
         if line.StartsWith(stackFrameLinePrefix) then
           // subtext
-          go ((Environment.NewLine, Text) :: ((line, Subtext) :: lines))
+          go ((line, Subtext) :: (Environment.NewLine, Text) :: lines)
+        else if String.IsNullOrWhiteSpace line then
+          go lines
         else
           // regular text
-          go ((Environment.NewLine, Text) :: ((line, Text) :: lines))
+          go ((line, Text) :: (Environment.NewLine, Text) :: lines)
     go []
 
   let literateColouriseExceptions (context : LiterateOptions) message =
@@ -536,12 +538,7 @@ module internal Formatting =
     let themedMessageParts =
       message.value |> literateFormatValue options message.fields |> snd
 
-    let themedExceptionParts =
-      let exnParts = literateColouriseExceptions options message
-      if not exnParts.IsEmpty then
-        [ Environment.NewLine, Text ]
-        @ exnParts
-      else []
+    let themedExceptionParts = literateColouriseExceptions options message
 
     let getLogLevelToken = function
       | Verbose -> LevelVerbose

--- a/src/tests/Logary.Facade.Tests/Facade.fs
+++ b/src/tests/Logary.Facade.Tests/Facade.fs
@@ -232,7 +232,6 @@ let tests =
           "System.Exception: errors field 1", Text
           nl, Text
           "System.Exception: errors field 2", Text
-          nl, Text //<-- Extra newline at the end
         ]
       Assert.literateMessagePartsEqual (template, fields, expectedMessageParts)
 

--- a/src/tests/Logary.Facade.Tests/Facade.fs
+++ b/src/tests/Logary.Facade.Tests/Facade.fs
@@ -229,13 +229,9 @@ let tests =
         [ nl, Text //<-- empty message will just start rendering exceptions on a new line
           "System.Exception: exn field", Text //<-- The exception
           nl, Text
-          nl, Text
           "System.Exception: errors field 1", Text
           nl, Text
-          nl, Text
           "System.Exception: errors field 2", Text
-          nl, Text
-          nl, Text
           nl, Text //<-- Extra newline at the end
         ]
       Assert.literateMessagePartsEqual (template, fields, expectedMessageParts)


### PR DESCRIPTION
After this change, there are far fewer new lines when exceptions printed.

This screenshot shows what it looks like *after*:
![image](https://cloud.githubusercontent.com/assets/570470/18953149/495d04ce-8690-11e6-96f6-5e501e027f40.png)
