### PR TITLE
Feature/load tests

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -20,12 +20,12 @@ NUGET
       elmah.corelibrary (>= 1.2.2)
       elmah.io.client (>= 2.0.29)
     EventStore.Client (3.9.4)
-    Expecto (3.0)
+    Expecto (3.0.1)
       Argu (>= 3.2)
       FSharp.Core (>= 3.1.2.5)
       Mono.Cecil (>= 0.9.6.4)
-    Expecto.FsCheck (3.0)
-      Expecto (>= 3.0)
+    Expecto.FsCheck (3.0.1)
+      Expecto (>= 3.0.1)
       FsCheck (>= 2.6.2)
       FSharp.Core (>= 3.1.2.5)
     FAKE (4.48)
@@ -116,8 +116,8 @@ GITHUB
     RingBuffer.fs (4557d607737e748b54eb6de3ec5e5cd02247b2a5)
       Hopac
   remote: logary/logary
-    src/Logary.CSharp.Facade/Facade.cs (397b5ee7733a36cb23c8887617470e427bbf1bb2)
-    src/Logary.Facade/Facade.fs (397b5ee7733a36cb23c8887617470e427bbf1bb2)
+    src/Logary.CSharp.Facade/Facade.cs (8fe3fce3f7d2602f2a4dc27419edfbce09c28a82)
+    src/Logary.Facade/Facade.fs (8fe3fce3f7d2602f2a4dc27419edfbce09c28a82)
 GROUP Examples
 REDIRECTS: ON
 FRAMEWORK: >= NET45

--- a/src/Logary/AssemblyInfo.fs
+++ b/src/Logary/AssemblyInfo.fs
@@ -3,5 +3,6 @@ open System.Reflection
 open System.Runtime.CompilerServices
 [<assembly: InternalsVisibleTo("Logary.CSharp")>]
 [<assembly: InternalsVisibleTo("Logary.Adapters.Facade")>]
+[<assembly: InternalsVisibleTo("Logary.LoadTests")>]
 [<assembly: Extension>]
 ()

--- a/src/tests/Logary.LoadTests/App.config
+++ b/src/tests/Logary.LoadTests/App.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.0.0" />
+  </dependentAssembly>
+</assemblyBinding></runtime></configuration>

--- a/src/tests/Logary.LoadTests/Logary.LoadTests.fs
+++ b/src/tests/Logary.LoadTests/Logary.LoadTests.fs
@@ -3,7 +3,9 @@ module Logary.LoadTests
 open System.Text
 open System.IO
 open Logary
+open Logary.Message
 open Logary.Targets
+open Logary.Formatting
 open Logary.Configuration
 open Hopac
 open Expecto
@@ -15,11 +17,23 @@ let withRegistry name testId contFn =
     let sb = new StringBuilder()
     new StringWriter(sb)
 
-  let out, err = textWriter (), textWriter ()
+  let out = textWriter ()
+
+  let formatter =
+    { new StringFormatter with
+        member x.format m =
+          match m.value with
+          | Event format ->
+            sprintf "%O|%s" m.name format
+          | _ ->
+            failwith "not supported"
+    }
 
   let target =
     Target.confTarget name (
-      TextWriter.create (TextWriter.TextWriterConf.create(out, err))
+      TextWriter.create (
+        TextWriter.TextWriterConf.create(out, out, formatter)
+      )
     )
 
   confLogary (sprintf "logary for %s.%i" name testId)
@@ -27,29 +41,53 @@ let withRegistry name testId contFn =
   |> withTarget target
   |> Config.validate
   |> runLogary
-  |> Job.bind contFn
+  |> Job.bind (fun logary ->
+    let dispose = Config.shutdownSimple logary |> Job.Ignore
+    Job.tryFinallyJobDelay (fun _ -> contFn (logary, out)) dispose
+  )
   |> Job.toAsync
 
 [<Tests>]
 let tests =
-
-  let testId () =
+  let gen =
     gen { let! name = Arb.generate<NonEmptyString>
           let! testId = Arb.generate<int64>
           return name, testId }
-    |> Gen.sample 0 1
+
+  let testId () =
+    gen
+    |> Gen.sample 10 1
     |> List.head
 
-  testList "load tests" [
+  testList "registry" [
     for i in 0 .. 10000 do
-      yield testCaseAsync "logger name" ((fun () ->
-        let (NonEmptyString name, testId : int64) = testId ()
-        withRegistry name testId <| fun logary ->
+      let (NonEmptyString name, testId : int64) = testId ()
+
+      yield testCaseAsync (sprintf "getLogger with name (%s.%i)" name testId) ((fun () ->
+        withRegistry name testId <| fun (logary, out) ->
           let pname = PointName.ofSingle (sprintf "%s.%i" name testId)
+          let msg = sprintf "Should have correct name: %O" pname
+          let logged = sprintf "From %s.%i" name testId
           job {
             let! logger = Registry.getLogger logary.registry pname
-            let msg = sprintf "Should have correct name: %O" pname
             Expect.equal logger.name pname msg
+            do! logger.infoWithAck (eventX logged)
+            do! Registry.Advanced.flushPending logary.registry
+            Expect.equal (out.ToString()) (sprintf "%O|%s\n" pname logged) "Should log right value"
+          }
+      ) ())
+
+      yield testCaseAsync (sprintf "Logger.getLoggerByName (%s.%i)" name testId) ((fun () ->
+        withRegistry name testId <| fun (logary, out) ->
+          let pname = PointName.ofSingle (sprintf "%s.%i" name testId)
+          let msg = sprintf "Should have correct name: %O" pname
+          let logged = sprintf "From %s.%i" name testId
+          let logger = Logging.getLoggerByPointName pname
+          job {
+            Expect.equal logger.name pname msg
+            do! logger.infoWithAck (eventX logged)
+            do! Registry.Advanced.flushPending logary.registry
+            Expect.equal (out.ToString()) (sprintf "%O|%s\n" pname logged) "Should log right value"
           }
       ) ())
   ]

--- a/src/tests/Logary.LoadTests/Logary.LoadTests.fs
+++ b/src/tests/Logary.LoadTests/Logary.LoadTests.fs
@@ -1,11 +1,57 @@
 module Logary.LoadTests
 
+open System.Text
+open System.IO
 open Logary
+open Logary.Targets
+open Logary.Configuration
+open Hopac
 open Expecto
+open Expecto.ExpectoFsCheck
+open FsCheck
+
+let withRegistry name testId contFn =
+  let textWriter () =
+    let sb = new StringBuilder()
+    new StringWriter(sb)
+
+  let out, err = textWriter (), textWriter ()
+
+  let target =
+    Target.confTarget name (
+      TextWriter.create (TextWriter.TextWriterConf.create(out, err))
+    )
+
+  confLogary (sprintf "logary for %s.%i" name testId)
+  |> withRule (Rule.createForTarget name)
+  |> withTarget target
+  |> Config.validate
+  |> runLogary
+  |> Job.bind contFn
+  |> Job.toAsync
 
 [<Tests>]
 let tests =
-  testList "" [
+
+  let testId () =
+    gen { let! name = Arb.generate<NonEmptyString>
+          let! testId = Arb.generate<int64>
+          return name, testId }
+    |> Gen.sample 0 1
+    |> List.head
+
+  testList "load tests" [
+    for i in 0 .. 10000 do
+      yield testCaseAsync "logger name" ((fun () ->
+        let (NonEmptyString name, testId : int64) = testId ()
+        withRegistry name testId <| fun logary ->
+          let pname = PointName.ofSingle (sprintf "%s.%i" name testId)
+          job {
+            let! logger = Registry.getLogger logary.registry pname
+            let msg = sprintf "Should have correct name: %O" pname
+            Expect.equal logger.name pname msg
+          }
+      ) ())
   ]
 
 [<EntryPoint>]

--- a/src/tests/Logary.LoadTests/Logary.LoadTests.fs
+++ b/src/tests/Logary.LoadTests/Logary.LoadTests.fs
@@ -1,0 +1,13 @@
+module Logary.LoadTests
+
+open Logary
+open Expecto
+
+[<Tests>]
+let tests =
+  testList "" [
+  ]
+
+[<EntryPoint>]
+let main argv =
+  Tests.runTestsInAssembly defaultConfig argv

--- a/src/tests/Logary.LoadTests/Logary.LoadTests.fsproj
+++ b/src/tests/Logary.LoadTests/Logary.LoadTests.fsproj
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Name>Logary.LoadTests</Name>
+    <AssemblyName>Logary.LoadTests</AssemblyName>
+    <RootNamespace>Logary.LoadTests</RootNamespace>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>ecb08593-6d2d-4dff-a403-93a83905b183</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>Full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>$(Platform)</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>$(Platform)</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../Logary/Logary.fsproj">
+      <Name>Logary.fsproj</Name>
+      <Project>{f7e5b6e8-5d55-4974-9ca7-4c94d810631f}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Logary.LoadTests.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Choose>
+    <When Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="Argu">
+          <HintPath>..\..\..\packages\Argu\lib\net40\Argu.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="Expecto">
+          <HintPath>..\..\..\packages\Expecto\lib\net40\Expecto.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="Expecto.FsCheck">
+          <HintPath>..\..\..\packages\Expecto.FsCheck\lib\net40\Expecto.FsCheck.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="FsCheck">
+          <HintPath>..\..\..\packages\FsCheck\lib\net45\FsCheck.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Mdb">
+          <HintPath>..\..\..\packages\Mono.Cecil\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Pdb">
+          <HintPath>..\..\..\packages\Mono.Cecil\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Rocks">
+          <HintPath>..\..\..\packages\Mono.Cecil\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\..\..\packages\Mono.Cecil\lib\net45\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/src/tests/Logary.LoadTests/Logary.LoadTests.fsproj
+++ b/src/tests/Logary.LoadTests/Logary.LoadTests.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Name>Logary.LoadTests</Name>
@@ -103,6 +103,27 @@
       <ItemGroup>
         <Reference Include="FsCheck">
           <HintPath>..\..\..\packages\FsCheck\lib\net45\FsCheck.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="Hopac.Core">
+          <HintPath>..\..\..\packages\Hopac\lib\net45\Hopac.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Hopac.Platform">
+          <HintPath>..\..\..\packages\Hopac\lib\net45\Hopac.Platform.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Hopac">
+          <HintPath>..\..\..\packages\Hopac\lib\net45\Hopac.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/tests/Logary.LoadTests/paket.references
+++ b/src/tests/Logary.LoadTests/paket.references
@@ -1,0 +1,3 @@
+FSharp.Core
+Expecto
+Expecto.FsCheck

--- a/src/tests/Logary.LoadTests/paket.references
+++ b/src/tests/Logary.LoadTests/paket.references
@@ -1,3 +1,4 @@
 FSharp.Core
 Expecto
 Expecto.FsCheck
+Hopac


### PR DESCRIPTION
A bug is hiding in this code:

Registry.fs:

```fsharp

/// handling flyweights
module internal Logging =
  open Hopac.Infixes
  open System
  open Logary.Target
  open Logary.Internals
  open Logary.Internals.Date

  /// Flyweight logger impl - reconfigures to work when it is configured, and
  /// until then throws away all log lines.
  type Flyweight(name) =
    let state = IVar ()
    let instaPromise = Alt.always (Promise (()))
    let insta = Alt.always ()

    let logger (f : Logger -> _) defaul =
      if IVar.Now.isFull state then
        let _, logger = IVar.Now.get state
        f logger
      else
        defaul

    interface Named with
      member x.name = name

    interface FlyweightLogger with
      member x.configured lm =
        getLogger lm.registry name >>= fun logger ->
        state *<= (lm, logger)

    interface Logger with
      member x.logWithAck logLevel messageFactory =
        logger (fun logger -> logger.logWithAck logLevel messageFactory) instaPromise

      member x.log logLevel messageFactory =
        logger (fun logger -> logger.log logLevel messageFactory) insta

      member x.level =
        Verbose

  /// Singleton configuration entry point: call from the runLogary code.
  let startFlyweights inst : Job<unit> =
    // Iterate through all flywieghts and set the current LogManager for them
    Globals.withFlyweights <| fun flyweights ->
      flyweights
      |> List.traverseJobA (fun f -> f.configured inst)
      >>- fun (_ : unit list) ->
        Globals.singleton := Some inst
        Globals.clearFlywieghts ()

  /// Singleton configuration exit point: call from shutdownLogary code
  let shutdownFlyweights () =
    Globals.singleton := None
    Globals.clearFlywieghts ()
```

Logging.fs:

```fsharp

[<CompiledName "GetLoggerByPointName">]
let getLoggerByPointName name =
  if box name = null then nullArg "name"
  match !Globals.singleton with
  | None ->
    let logger = Flyweight name :> FlyweightLogger
    Globals.addFlyweight logger
    logger :> Logger

  | Some inst ->
    inst.runtimeInfo.logger.verbose (
      eventX "Getting logger by name {name}" >> setField "name" (name.ToString()))

    name
    |> Registry.getLogger inst.registry
    |> PromisedLogger.create name
```

And Globals.fs:

```fsharp

/// Module that is the ONLY module allowed to have global variables; created so
/// that consumer applications may call into Logary without having a reference
/// to the LogManager first.
///
/// The globals in this module are configured in module "Logging".
module internal Globals =
  open Logary

  /// This is the "Global Variable" containing the last configured
  /// Logary instance. If you configure more than one logary instance
  /// this will be replaced. It is internal so that noone
  /// changes it from the outside. Don't use this directly if you can
  /// avoid it, and instead take a c'tor dependency on LogaryRegistry
  /// or use IoC with a contextual lookup to resolve proper loggers.
  let singleton : LogaryInstance option ref = ref None

  /// This is the global console semaphore to use when printing in a multi-
  /// threaded manner to STDOUT or STDERR.
  let consoleSemaphore = obj ()

  /// A list of all loggers yet to be configured
  let private flyweights : FlyweightLogger list ref = ref []

  let private flyweightLock = obj ()

  let addFlyweight (fwl : FlyweightLogger) =
    lock flyweightLock <| fun _ ->
      flyweights := fwl :: !flyweights

  /// Gives f a snapshot of the current flyweights
  let withFlyweights f =
    f !flyweights

  let clearFlywieghts () =
    lock flyweightLock (fun _ -> flyweights := [])
```

With the tests in this PR.