### PR TITLE
[WIP] Facade: enable further customising output

### DIFF
--- a/src/tests/Logary.Facade.Tests/Facade.fs
+++ b/src/tests/Logary.Facade.Tests/Facade.fs
@@ -7,35 +7,74 @@ open Logary.Facade.Literals
 open Logary.Facade.Literate
 open Logary.Facade.LiterateExtensions
 
+type ColouredBits = string * ConsoleColor
+
+let getColouredBitsForMessage options (message: Message) messageParts =
+  let timestampDto = DateTimeOffset(DateTimeOffset.ticksUTC message.timestamp, TimeSpan.Zero)
+  let timestampTimeString = timestampDto.LocalDateTime.ToString("HH:mm:ss", options.formatProvider)
+  let logLevel, logLevelToken = message.level, LiterateFormatting.tokeniseLogLevel message.level
+  let expectedTokens = [ "[",                               Punctuation
+                         timestampTimeString,              Subtext
+                         " ",                               Subtext
+                         options.getLogLevelText logLevel,  logLevelToken
+                         "] ",                              Punctuation ]
+                         @ messageParts
+                         @ [ Environment.NewLine, Text ]
+  let applyTheme (text : string, token) = text, options.theme token
+  expectedTokens |> Seq.map applyTheme |> Seq.toList
 
 type Expect =
-  static member literateWrittenColourPartsEqual (options, message, expectedColourParts) =
-    let writtenParts = ResizeArray<string * ConsoleColor>()
-    let outputWriter (sem : obj) (colouredBits : (string * ConsoleColor) seq) = writtenParts.AddRange colouredBits
-    let target = LiterateConsoleTarget([||], Info, options=options, outputWriter=outputWriter) :> Logger
-    let applyTheme (text : string, token) = text, options.theme token
-    target.logWithAck Info (fun _ -> message) |> Async.RunSynchronously
-    Expect.equal (expectedColourParts |> Seq.map applyTheme |> Seq.toList)
+  /// Asserts the `LiterateConsoleTarget` will render the expected colour parts to the output writer.
+  /// Note the `expectedParts` must contain everthing that will be rendered (including the default
+  /// output parts such as the line prefix "[00:00:00 INF] ").
+  static member literateRenderedPartsEqual (lrc, message, expectedParts) =
+    let writtenParts = ResizeArray<ColouredBits>()
+    let inMemoryOutputWriter (colouredBits : ColouredBits seq) = writtenParts.AddRange colouredBits
+    let target = LiterateConsoleTarget([|"Facade"; "Tests"|], Verbose, renderingContext=lrc, outputWriter=inMemoryOutputWriter) :> Logger
+    let applyTheme (text : string, token) = text, lrc.options.theme token
+    target.logWithAck message.level (fun _ -> message) |> Async.RunSynchronously
+    Expect.equal (expectedParts |> Seq.map applyTheme |> Seq.toList)
                  (writtenParts |> Seq.toList)
-                  "The parts must match"
+                 "literate rendered parts must match"
 
-  static member literateMessagePartsEqual (template, fields, expectedMessageParts, ?options, ?logLevel, ?tokeniser) =
+  static member literateMessagePartsEqualOldCtor (template, fields, expectedMessageParts, ?options) =
     let options = defaultArg options (LiterateOptions.create())
-    let tokeniser = defaultArg tokeniser (fun o m -> options.tokenise.message o m |> List.ofSeq)
-    let logLevel = defaultArg logLevel Info
-    let now = Global.timestamp ()
-    let nowDto = DateTimeOffset(DateTimeOffset.ticksUTC now, TimeSpan.Zero)
-    let msg = Message.event logLevel template |> fun m -> { m with fields = fields; timestamp = now }
-    let nowTimeString = nowDto.LocalDateTime.ToString("HH:mm:ss", options.formatProvider)
-    let actualTokens = tokeniser options msg
-    let expectedTokens = [  "[",                              Punctuation
-                            nowTimeString,                    Subtext
-                            " ",                              Subtext
-                            options.getLogLevelText logLevel, LevelInfo
-                            "] ",                             Punctuation ]
-                            @ expectedMessageParts
+    let writtenColourBits = ResizeArray<ColouredBits>()
+    let inMemoryOutputWriter (colouredBits : ColouredBits seq) = writtenColourBits.AddRange colouredBits
+    let logLevel = Info
+    let message = { Message.event logLevel template with fields = fields }
+    let targetViaOldCtor = LiterateConsoleTarget(name = [|"Facade"; "Tests"|],
+                                                 minLevel = Verbose,
+                                                 options = options,
+                                                 outputWriter = inMemoryOutputWriter) :> Logger
+    targetViaOldCtor.logWithAck logLevel (fun _ -> message) |> Async.RunSynchronously
+    let expectedColourBits = getColouredBitsForMessage options message expectedMessageParts
+    let actualColourBits = writtenColourBits |> Seq.toList
+    Expect.equal expectedColourBits actualColourBits "literate rendered message parts must match"
 
-    Expect.equal actualTokens expectedTokens "literate tokenised parts must be correct"
+  static member literateMessagePartsEqualNewCtor (template, fields, expectedMessageParts, ?options) =
+    let lrc = LiterateRenderingContext.create (?options=options)
+    let options = lrc.options
+    let writtenParts = ResizeArray<ColouredBits>()
+    let inMemoryOutputWriter (colouredBits : ColouredBits seq) = writtenParts.AddRange colouredBits
+    let now = Global.timestamp ()
+    let logLevel = Info
+    let message = { Message.event logLevel template with fields = fields; timestamp = now }
+    let targetViaNewCtor = LiterateConsoleTarget(name = [|"Facade"; "Tests"|],
+                                                 minLevel = Verbose,
+                                                 renderingContext = lrc,
+                                                 outputWriter = inMemoryOutputWriter) :> Logger
+    targetViaNewCtor.logWithAck logLevel (fun _ -> message) |> Async.RunSynchronously
+    let expectedColourBits = getColouredBitsForMessage options message expectedMessageParts
+    let actualColourBits = writtenParts |> Seq.toList
+    Expect.equal expectedColourBits actualColourBits "literate rendered message parts must match"
+
+  /// Asserts the LiterateConsoleTarget will render the expected message template parts.
+  /// Note the `expectedMessageParts` should NOT include the default output parts such as
+  /// the message line prefix "[00:00:00 INF] ".
+  static member literateMessagePartsEqual (template, fields, expectedMessageParts, ?options) =
+    Expect.literateMessagePartsEqualOldCtor (template, fields, expectedMessageParts, ?options = options)
+    Expect.literateMessagePartsEqualNewCtor (template, fields, expectedMessageParts, ?options = options)
 
 [<Tests>]
 let tests =
@@ -82,7 +121,7 @@ let tests =
       let msg = msg |> Message.setLevel Warn
       Expect.equal msg.level Warn "Should have Warn level now"
 
-    testCase "LiterateConsoleTarget logSimple" <| fun _ ->
+    testCase "logSimple" <| fun _ ->
       let logger = LiterateConsoleTarget([| "Facade"; "Tests" |], Warn) :> Logger
       Message.event Info "Aliens descended" |> logger.logSimple
 
@@ -93,37 +132,41 @@ let tests =
       let logger = [| "Facade"; "Tests" |] |> Targets.create Error
       Message.event Verbose "Hi {name}" |> Message.setField "name" "haf" |> logger.logSimple
 
-    testCase "extract invalid property tokens as text" <| fun _ ->
-      let template = "Hi {ho:##.###}, we're { something going on } special"
-      let fields = Map [ "ho", box "hola"; "something going on", box "very" ]
-      let tokens = EventTemplateParser.parse template |> Seq.toList
-      Expect.equal (tokens |> Seq.length) 5 "Extracts 4 texts parts and 1 property part"
-      Expect.equal tokens
-                   [ EventTemplateParser.TextToken ("Hi ")
-                     EventTemplateParser.PropToken ("ho", "##.###")
-                     EventTemplateParser.TextToken (", we're ") // <- a quirk of the parser
-                     EventTemplateParser.TextToken ("{ something going on }")
-                     EventTemplateParser.TextToken (" special") ]
-                   "Should extract correct name and format parts"
+    testList "EventTemplateParser" [
 
-    testCase "handles evil property strings correctly" <| fun _ ->
-      let template = "{a}{b}{  c}{d  } {e} fghij {k}} {l} m {{}}"
-      // validity:     +  +  --    --   +         +    +     --
-      let expectedPropertyNames = ["a"; "b"; "e"; "k"; "l"]
-      let subject = EventTemplateParser.parse template |> Seq.toList
-      Expect.equal (subject |> List.choose (function EventTemplateParser.PropToken (n,f) -> Some n | _ -> None))
-                   expectedPropertyNames
-                   "Should extract relevant names"
+      testCase "extract invalid property tokens as text" <| fun _ ->
+        let template = "Hi {ho:##.###}, we're { something going on } special"
+        let fields = Map [ "ho", box "hola"; "something going on", box "very" ]
+        let tokens = EventTemplateParser.parse template |> Seq.toList
+        Expect.equal (tokens |> Seq.length) 5 "Extracts 4 texts parts and 1 property part"
+        Expect.equal tokens
+                     [ EventTemplateParser.TextToken ("Hi ")
+                       EventTemplateParser.PropToken ("ho", "##.###")
+                       EventTemplateParser.TextToken (", we're ") // <- a quirk of the parser
+                       EventTemplateParser.TextToken ("{ something going on }")
+                       EventTemplateParser.TextToken (" special") ]
+                     "Should extract correct name and format parts"
 
-    testCase "treats `{{` and `}}` as escaped braces, resulting in a single brace in the output" <| fun _ ->
-      let template = "hello {{@nonPropWithFormat:##}} {{you}} {are} a {{NonPropNoFormat}}"
-      let tokens = EventTemplateParser.parse template |> Seq.toList
-      Expect.equal tokens
-                    [ EventTemplateParser.TextToken("hello {@nonPropWithFormat:##} {you} ")
-                      EventTemplateParser.PropToken("are", null)
-                      EventTemplateParser.TextToken(" a {NonPropNoFormat}") ]
+      testCase "handles evil property strings correctly" <| fun _ ->
+        let template = "{a}{b}{  c}{d  } {e} fghij {k}} {l} m {{}}"
+        // validity:     +  +  --    --   +         +    +     --
+        let expectedPropertyNames = ["a"; "b"; "e"; "k"; "l"]
+        let subject = EventTemplateParser.parse template |> Seq.toList
+        Expect.equal (subject |> List.choose (function EventTemplateParser.PropToken (n,f) -> Some n | _ -> None))
+                     expectedPropertyNames
+                     "Should extract relevant names"
 
-                   "double open or close braces are escaped"
+      testCase "treats `{{` and `}}` as escaped braces, resulting in a single brace in the output" <| fun _ ->
+        let template = "hello {{@nonPropWithFormat:##}} {{you}} {are} a {{NonPropNoFormat}}"
+        let tokens = EventTemplateParser.parse template |> Seq.toList
+        Expect.equal tokens
+                      [ EventTemplateParser.TextToken("hello {@nonPropWithFormat:##} {you} ")
+                        EventTemplateParser.PropToken("are", null)
+                        EventTemplateParser.TextToken(" a {NonPropNoFormat}") ]
+
+                     "double open or close braces are escaped"
+    ]
+
     testCase "literate tokenises with field names correctly" <| fun _ ->
       let template = "Added {item} to cart {cartId} for {loginUserId} who now has total ${cartTotal}"
       let itemName, cartId, loginUserId, cartTotal = "TicTacs", Guid.NewGuid(), "AdamC", 123.45M
@@ -170,10 +213,10 @@ let tests =
           cartTotal.ToString(),   NumericSymbol ]
       Expect.literateMessagePartsEqual (template, fields, expectedMessageParts)
 
-    testCase "literate default tokeniser uses the options `getLogLevelText()` correctly" <| fun _ ->
+    testCase "literate tokeniser uses the options `getLogLevelText()` correctly" <| fun _ ->
       let customGetLogLevelText = function Verbose->"A"|Debug->"B"|Info->"C"|Warn->"D"|Error->"E"|Fatal->"F"
-      let options = { LiterateOptions.createInvariant() with
-                        getLogLevelText = customGetLogLevelText }
+      let options = { LiterateOptions.createInvariant() with getLogLevelText = customGetLogLevelText }
+      let tokeniseContext = { options = options; tokeniser = LiterateTokeniser.create () }
       let now = Global.timestamp ()
       let nowDto = DateTimeOffset(DateTimeOffset.ticksUTC now, TimeSpan.Zero)
       let msg level = Message.event level "" |> fun m -> { m with timestamp = now }
@@ -185,7 +228,7 @@ let tests =
         Error,    LevelError,     "E"
         Fatal,    LevelFatal,     "F" ]
       |> List.iter (fun (logLevel, expectedLevelToken, expectedText) ->
-        let tokens = LiterateFormatting.tokeniseMessage options (msg logLevel) |> List.ofSeq
+        let tokens = LiterateFormatting.tokeniseMessage tokeniseContext (msg logLevel) |> List.ofSeq
         Expect.equal tokens [ "[",            Punctuation
                               nowTimeString,  Subtext
                               " ",            Subtext
@@ -246,34 +289,28 @@ let tests =
           " who now has total $", Text
           cartTotal.ToString(),   NumericSymbol ]
       Expect.literateMessagePartsEqual (template, fields, expectedMessageParts, options)
-    
-    testCase "customising the Literate output template is possible" <| fun _ ->
-      let template = "Hello from the {where}"
-      let whereText = "other side"
+
+    testCase "customising the literate output with an arbitrary prefix and suffix works" <| fun _ ->
+      let template = "Hello from {where}"
+      let whereText = "the other side"
       let fields = Map [ "where", box whereText ]
-
-      let myCustomOutputTemplate (options : LiterateOptions) (message : Message) =
-        seq {
-          yield "<arbitrary prefix> ", Text
-          yield! options.tokenise.pointValue options message.fields message.value
-          yield! options.tokenise.messageExceptions options message
-          yield "arbitrary suffix>", Text
-        }
-
-      let defaultOptions = LiterateOptions.create()
-      let customisedOptions = { defaultOptions with
-                                  tokenise = { defaultOptions.tokenise with
-                                                message = myCustomOutputTemplate } }
+      
+      let myCustomMessageTokeniser context message =
+        seq { yield "<arbitrary prefix> ", Text
+              yield! context.tokeniser.pointValue context message.fields message.value
+              yield! context.tokeniser.messageExns context message
+              yield " <arbitrary suffix>", Text }
+      let customRenderingContext = LiterateRenderingContext.create (messageTokeniser=myCustomMessageTokeniser)
 
       let expectedParts =
         [ "<arbitrary prefix> ",  Text
-          "Hello from the ",      Text
-          "other side",           StringSymbol
-          "arbitrary suffix>",    Text
+          "Hello from ",          Text
+          "the other side",       StringSymbol
+          " <arbitrary suffix>",  Text
           Environment.NewLine,    Text ] // the LiterateConsoleTarget appends a newline after each message
 
       let message = { Message.event Info template with fields = fields }
-      Expect.literateWrittenColourPartsEqual (customisedOptions, message, expectedParts)
+      Expect.literateRenderedPartsEqual (customRenderingContext, message, expectedParts)
 
     testCase "format template with invalid property correctly" <| fun _ ->
       // spaces are not valid in property names, so the 'property' is treated as text

--- a/src/tests/Logary.Facade.Tests/Facade.fs
+++ b/src/tests/Logary.Facade.Tests/Facade.fs
@@ -5,6 +5,7 @@ open Expecto
 open Logary.Facade
 open Logary.Facade.Literals
 open Logary.Facade.Literate
+open Logary.Facade.LiterateExtensions
 
 type internal TemplateToken =
   | TextToken of string
@@ -26,7 +27,7 @@ let internal parseTemplateTokens template =
 type Expect =
   static member literateMessagePartsEqual (template, fields, expectedMessageParts, ?options, ?logLevel, ?tokeniser) =
     let options = defaultArg options (LiterateOptions.create())
-    let tokeniser = defaultArg tokeniser Formatting.literateDefaultTokeniser
+    let tokeniser = defaultArg tokeniser (fun o m -> options.tokeniseMessage o m |> List.ofSeq)
     let logLevel = defaultArg logLevel Info
     let now = Global.timestamp ()
     let nowDto = DateTimeOffset(DateTimeOffset.ticksUTC now, TimeSpan.Zero)
@@ -190,7 +191,7 @@ let tests =
         Error,    LevelError,     "E"
         Fatal,    LevelFatal,     "F" ]
       |> List.iter (fun (logLevel, expectedLevelToken, expectedText) ->
-        let tokens = Formatting.literateDefaultTokeniser options (msg logLevel)
+        let tokens = LiterateFormatting.tokeniseMessage options (msg logLevel) |> List.ofSeq
         Expect.equal tokens [ "[",            Punctuation
                               nowTimeString,  Subtext
                               " ",            Subtext


### PR DESCRIPTION
This will fix #230.

TODOs
 - [x] Add some tests that document how to customise the 'output template' as described in #230 
 - [ ] Verify that we want facade consumers to have the ability to parse event templates
 - [ ] Verify the breaking changes are acceptable (they are minor, e.g. `LiterateOptions` record fields changed).
