### PR TITLE
Facade/Literate output properties

### DIFF
--- a/src/Logary.Facade.Tests/Facade.fs
+++ b/src/Logary.Facade.Tests/Facade.fs
@@ -58,7 +58,7 @@ type Expect =
   /// Asserts that the rendered output (`ColouredText`) matches the expected tokens (`TokenisedPart`) using
   /// the provided `LiterateOptions` (and theme)
   static member literateWrittenColouredTextEquals (writtenColouredTextParts : ColouredText seq,
-                                                   expectedTokens : TokenisedPart list,
+                                                   expectedTokens : LiterateTokenisation.TokenisedPart list,
                                                    ?options : LiterateOptions) =
 
     let options = defaultArg options (LiterateOptions.create())
@@ -269,7 +269,7 @@ let tests =
         Error,    LevelError,     "E"
         Fatal,    LevelFatal,     "F" ]
       |> List.iter (fun (logLevel, expectedLevelToken, expectedText) ->
-        let tokens = Formatting.literateDefaultTokeniser options (msg logLevel)
+        let tokens = LiterateTokenisation.tokeniseMessage options (msg logLevel)
         Expect.equal tokens [ "[",            Punctuation
                               nowTimeString,  Subtext
                               " ",            Subtext

--- a/src/Logary.Facade.Tests/Facade.fs
+++ b/src/Logary.Facade.Tests/Facade.fs
@@ -27,13 +27,13 @@ let internal parseTemplateTokens template =
 type ColouredText = string * ConsoleColor
 
 type DateTimeOffset with
-  member x.ToLiterateTime (?options : LiterateOptions) =
+  member x.ToLiterateTime (?options: LiterateOptions) =
     let options = defaultArg options (LiterateOptions.create())
     x.ToLocalTime().ToString("HH:mm:ss", options.formatProvider)
 
 type System.Int64 with
   member x.ToDateTimeOffsetUtc() = DateTimeOffset(DateTimeOffset.ticksUTC x, TimeSpan.Zero)
-  member x.ToLiterateTimeString (options : LiterateOptions) = x.ToDateTimeOffsetUtc().ToLiterateTime(options)
+  member x.ToLiterateTimeString (options: LiterateOptions) = x.ToDateTimeOffsetUtc().ToLiterateTime(options)
 
 [<AutoOpen>]
 type LiterateTesting =
@@ -43,7 +43,7 @@ type LiterateTesting =
 
     // Insteading of writing out to the console, write to an in-memory list so we can capture the values
     let writtenParts = ResizeArray<ColouredText>()
-    let writtenPartsOutputWriter _ (bits : ColouredText list) = writtenParts.AddRange bits
+    let writtenPartsOutputWriter _ (bits: ColouredText list) = writtenParts.AddRange bits
 
     let target = LiterateConsoleTarget(name = [||],
                                        minLevel = Verbose,
@@ -57,9 +57,9 @@ type LiterateTesting =
 type Expect =
   /// Asserts that the rendered output (`ColouredText`) matches the expected tokens (`TokenisedPart`) using
   /// the provided `LiterateOptions` (and theme)
-  static member literateWrittenColouredTextEquals (writtenColouredTextParts : ColouredText seq,
-                                                   expectedTokens : LiterateTokenisation.TokenisedPart list,
-                                                   ?options : LiterateOptions) =
+  static member literateWrittenColouredTextEquals (writtenColouredTextParts: ColouredText seq,
+                                                   expectedTokens: LiterateTokenisation.TokenisedPart list,
+                                                   ?options: LiterateOptions) =
 
     let options = defaultArg options (LiterateOptions.create())
 
@@ -101,7 +101,7 @@ type Expect =
                   | Some theme -> { LiterateOptions.create() with theme = theme }
                   | None -> LiterateOptions.create()
     let writtenParts = ResizeArray<ColouredText>()
-    let writtenPartsOutputWriter _ (bits : ColouredText list) = writtenParts.AddRange bits
+    let writtenPartsOutputWriter _ (bits: ColouredText list) = writtenParts.AddRange bits
     let target = LiterateConsoleTarget(name = [|"Facade";"Tests"|],
                                        minLevel = Verbose,
                                        options = options,
@@ -128,12 +128,12 @@ let tests =
   Global.initialise { Global.defaultConfig with getLogger = Targets.create Fatal }
 
   testList "generic" [
-    testProperty "DateTime" <| fun (dt : DateTime) ->
+    testProperty "DateTime" <| fun (dt: DateTime) ->
       let ticks = dt |> DateTime.timestamp |> DateTime.ticksUTC
       let recreated = DateTime(ticks, DateTimeKind.Utc).Ticks
       Expect.equal recreated (dt.Ticks) "should equal on ticks after conversion"
 
-    testProperty "DateTimeOffset" <| fun (ts : DateTimeOffset) ->
+    testProperty "DateTimeOffset" <| fun (ts: DateTimeOffset) ->
       let ticks = ts |> DateTimeOffset.timestamp |> DateTimeOffset.ticksUTC
       let recreated = DateTimeOffset(ticks, TimeSpan.Zero).Ticks
       Expect.equal recreated (ts.Ticks) "should equal after conversion"
@@ -282,7 +282,7 @@ let tests =
                       (sprintf "expect log level %A to render as token %A with text %s" logLevel expectedLevelToken expectedText)
       )
     
-    testProperty "literate theme is applied correctly" <| fun (theme : LiterateToken -> ConsoleColor) ->
+    testProperty "literate theme is applied correctly" <| fun (theme: LiterateToken -> ConsoleColor) ->
       let options = { LiterateOptions.create() with theme = theme }
       let fields = Map.ofList [ "where", box "The Other Side" ]
       let message = { Message.event Warn "Hello from {where}" with fields = fields }

--- a/src/Logary.Facade.Tests/Facade.fs
+++ b/src/Logary.Facade.Tests/Facade.fs
@@ -439,10 +439,14 @@ let tests =
       let level = Info
       let source = "Abc.Def.Ghi"
       let options = LiterateOptions.create()
-      let msgTemplate = "Hello {who}"
-      let whoValue = "world"
+      let templatePropName1, templatePropValue1 = "who", "world"
+      let nonTemplatePropName1, nonTemplatePropValue1 = "ntprop1", Guid.NewGuid()
+      let nonTemplatePropName2, nonTemplatePropValue2 = "ntprop2", Guid.NewGuid()
+      let msgTemplate = "Hello {" + templatePropName1 + "}"
       let msg = Message.event level msgTemplate
-                |> Message.setField "who" whoValue
+                |> Message.setField templatePropName1 templatePropValue1
+                |> Message.setField nonTemplatePropName1 nonTemplatePropValue1
+                |> Message.setField nonTemplatePropName2 nonTemplatePropValue2
                 |> Message.setSingleName source
                 |> Message.addExn (exn "ex1")
                 |> Message.addExn (exn "ex2")
@@ -455,6 +459,12 @@ let tests =
           "{newline}",                        nl
           "{tab}",                            "\t"
           "{message}",                        "Hello world"
+          "{newLineIfNext}{properties}",      nl + " - " + nonTemplatePropName1 + ": " + (string nonTemplatePropValue1) +
+                                              nl + " - " + nonTemplatePropName2 + ": " + (string nonTemplatePropValue2)
+          "{newLineIfNext} {properties}",     "  - " + nonTemplatePropName1 + ": " + (string nonTemplatePropValue1) +
+                                              nl + " - " + nonTemplatePropName2 + ": " + (string nonTemplatePropValue2)
+          "{properties}",                     " - " + nonTemplatePropName1 + ": " + (string nonTemplatePropValue1) +
+                                              nl + " - " + nonTemplatePropName2 + ": " + (string nonTemplatePropValue2)
           "{exceptions}",                     nl + "System.Exception: ex2" + nl + "System.Exception: ex1"
           "",                                 "" ]
 

--- a/src/Logary.Facade.Tests/Facade.fs
+++ b/src/Logary.Facade.Tests/Facade.fs
@@ -92,6 +92,7 @@ type Expect =
         yield ">",                                              Punctuation
         yield Environment.NewLine,                              Text ]
 
+    let writtenParts = LiterateTesting.getWrittenColourParts (message, options = options)
     let actualParts = writtenParts |> List.ofSeq
     let expectedParts = expectedTokens |> List.map (fun (s, t) -> s, options.theme t)
     Expect.sequenceEqual actualParts expectedParts "literate tokenised parts must be correct"
@@ -118,7 +119,7 @@ type Expect =
   /// Asserts that the LiterateConsoleTarget renders the template (with the provided fields, options, and tokeniser) and
   /// outputs coloured text that (when themed) will match the expected tokens.
   static member literateOutputPartsEqual (message, expectedTokens, ?options, ?customTokeniser) =
-    let writtenParts = LiterateTesting.getWrittenColourParts (message, ?customTokeniser = customTokeniser, ?options = options)    
+    let writtenParts = LiterateTesting.getWrittenColourParts (message, ?customTokeniser = customTokeniser, ?options = options)
     Expect.literateWrittenColouredTextEquals (writtenParts, expectedTokens, ?options = options)
 
 [<Tests>]

--- a/src/Logary.Facade/Facade.fs
+++ b/src/Logary.Facade/Facade.fs
@@ -299,14 +299,6 @@ type LoggingConfig =
     /// adapter to replace this semaphore with a global semaphore.
     consoleSemaphore: obj }
 
-[<AutoOpen>]
-module internal Helpers = 
-  /// replaces the built-in `isNull` function so we can still use it when < FSharp.Core 4.0
-  let inline isNull o =
-    match o with
-    | null -> true
-    | _ -> false
-
 module Literate =
   /// The output tokens, which can be potentially coloured.
   type LiterateToken =

--- a/src/Logary.Facade/Facade.fs
+++ b/src/Logary.Facade/Facade.fs
@@ -300,6 +300,14 @@ type LoggingConfig =
     /// adapter to replace this semaphore with a global semaphore.
     consoleSemaphore: obj }
 
+[<AutoOpen>]
+module internal Helpers = 
+  /// replaces the built-in `isNull` function so we can still use it when < FSharp.Core 4.0
+  let inline isNull o =
+    match o with
+    | null -> true
+    | _ -> false
+
 module Literate =
   /// The output tokens, which can be potentially coloured.
   type LiterateToken =
@@ -381,11 +389,6 @@ module internal FsMtParser =
     override x.ToString() = x.AppendPropertyString(StringBuilder()).ToString()
 
   module internal ParserBits =
-
-    let inline isNull o =
-      match o with
-      | null -> true
-      | _ -> false
 
     let inline isLetterOrDigit c = System.Char.IsLetterOrDigit c
     let inline isValidInPropName c = c = '_' || System.Char.IsLetterOrDigit c


### PR DESCRIPTION
Adds support for `{properties}` and `{newLineIfNext}` in the `LiterateConsole` `outputTemplate`. Currently, if libraries like Suave write a log `Message` out with any **fields that are not included in the message template**, they will not be rendered and there is no way to easily enable it. 

This feature would allow you add `{properties}` to the output template:
```fsharp
let outputTemplate =
  "[{level}] {timestampUtc:u} {message} [{source}]{newLineIfNext}{properties}{exceptions}"

let singleLetterLogLevel = function
  | Verbose-> "V"
  | Debug-> "D"
  | Info-> "I"
  | Warn-> "W"
  | Error-> "E"
  | Fatal-> "F"

let loggerOptions =
  { Literate.LiterateOptions.create() with
      getLogLevelText = singleLetterLogLevel }

let logger = LiterateConsoleTarget(
              [|"Suave";"Example"|],
              Verbose,
              options=loggerOptions,
              outputTemplate=outputTemplate) :> Logger 
```

The following screen shot shows the line ` - cookieName: counter`; it is an example of an important field that is part of the log `Message` but **not part of the message template**. Without this feature, we cannot see the `cookieName`.

![image](https://cloud.githubusercontent.com/assets/570470/25318232/d712951a-28cd-11e7-90f4-a9c20086a00d.png)

~(Note: I'm still experimenting with this idea a little. I'm raising PR now to get high level feedback).~