### PR TITLE
Better format value without unit in Application Insights Target

### DIFF
--- a/src/targets/Logary.Targets.ApplicationInsights/Targets_AppInsights.fs
+++ b/src/targets/Logary.Targets.ApplicationInsights/Targets_AppInsights.fs
@@ -68,7 +68,7 @@ module internal Impl =
   let fieldValue f = 
       let (Logary.Field (v, un)) = f
       match un with
-      | None -> Units.formatValue v
+      | None -> Formatting.MessageParts.formatValue Environment.NewLine 0 v
       | Some u -> Units.formatWithUnit Units.UnitOrientation.Prefix u v
   
   let scaleUnit = function


### PR DESCRIPTION
@Thorium 
As commented [here](https://github.com/logary/logary/issues/246#issuecomment-316907468), this PR uses `Formatting.MessageParts.formatValue` instead of `Units.formatValue` for field without unit.