### PR TITLE
Error in "Hello World (F#)" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ let randomMetric (pn : PointName) : Job<Metric> =
   let ticker pn (rnd : Random, prevValue) =
     let value = rnd.NextDouble()
     let msg = Message.gauge pn (Float value)
-    (rnd, value), [ msg ]
+    (rnd, value), [| msg |]
 
   let state = Random(), 0.0
 


### PR DESCRIPTION
Copy & paste and got this error message:

```F#
Type mismatch. Expecting a
    'Random * float -> (Random * float) * Message []'    
but given a
    'Random * float -> (Random * float) * Message list'    
The type 'Message []' does not match the type 'Message list'
```