### PR TITLE
File target C# example fails on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,9 +1010,11 @@ let fileConf =
 Or in C#:
 
 ```csharp
+// set 'logDir' to specific path like Environment.CurrentDirectory if you are on windows
 .Target<File.Builder>(
     "file",
-    file => file.Target.Naming("{service}-{host}-{datetime}", "log").Done())
+    file => file.Target.FileSystem(new FileSystem.DotNetFileSystem(logDir)) 
+                       .Naming("{service}-{host}-{datetime}", "log").Done())
 ```
 
 ### Policies & specifications


### PR DESCRIPTION
By default the "FileSystem" is initialized to '/var/lib/logs' path at https://github.com/logary/logary/blob/0435a4896f517c19f3eaabfe28913e9604c3f7cf/src/Logary/Targets_Core.fs#L1183  and that throws an exception like `System.InvalidOperationException: Path 'C:\Dev\dsa\bin\Debug' is not within root '/var/lib/logs'` at runtime.
The F# example has a `logDir` parameter, but no explanation. Maybe the comment saves a few minutes for others...