### PR TITLE
Defines schema for sql migrations

### DIFF
--- a/src/legacy/Logary.Targets.DB.Migrations/Migrations.fs
+++ b/src/legacy/Logary.Targets.DB.Migrations/Migrations.fs
@@ -57,13 +57,13 @@ type GaugesTable() =
     |> ignore
 
     // if you're just shipping
-    base.Create.Index("IX_Gauges_EpochNanos").OnTable(Defaults.GaugesTable)
+    base.Create.Index("IX_Gauges_EpochNanos").OnTable(Defaults.GaugesTable).InSchema(Defaults.Schema)
       .OnColumn("EpochNanos").Descending().WithOptions().NonClustered()
     |> ignore
 
     // if you're also reading
     if indexForReading then
-      base.Create.Index("IX_Gauges_EpochNanos.Name.Level").OnTable(Defaults.GaugesTable)
+      base.Create.Index("IX_Gauges_EpochNanos.Name.Level").OnTable(Defaults.GaugesTable).InSchema(Defaults.Schema)
         .WithOptions().NonClustered()
         .OnColumn("EpochNanos").Descending()
         .OnColumn("Name").Ascending()
@@ -89,7 +89,7 @@ type EventsTable() =
     |> ignore
     
     // if you're just storing and deleting:
-    base.Create.Index("IX_Events_EpochNanos").OnTable(Defaults.EventsTable)
+    base.Create.Index("IX_Events_EpochNanos").OnTable(Defaults.EventsTable).InSchema(Defaults.Schema)
       .OnColumn("EpochNanos").Descending().WithOptions().NonClustered()
     |> ignore
 

--- a/src/legacy/Logary.Targets.DB.Tests/DBTarget.fs
+++ b/src/legacy/Logary.Targets.DB.Tests/DBTarget.fs
@@ -111,7 +111,6 @@ let read (m: Map<string, obj>) k =
     Tests.failtestf "converting key %s to %s failed, was: %s."
       k typeof<'a>.Name (m.[k].GetType().Name)
 
-
 [<Tests>]
 let targetTests =
   let flush = Target.flush >> Job.Ignore
@@ -258,6 +257,19 @@ let migrationTests =
     testCase "migating down with reading index" <| fun _ ->
       Runner(fac, forgetful).MigrateDown(Runner.IndexForReading)
     ]
+
+//The below requires a localhost MS SQL Server.
+//It will up and down the logary schema.
+//[<Tests>]
+let sqlservermigrationTests = 
+  let fac = SqlServer.SqlServerProcessorFactory()
+  let connectionString = "Server=localhost;Database=Logary_Migration_Test;Integrated Security=true;"
+  testList "migrating sqlserver db up and down" [
+
+    testCase "migrating up" <| fun _ -> 
+      Runner(fac,connectionString).MigrateUp()
+      Runner(fac,connectionString).MigrateDown()
+  ]
 
 [<EntryPoint>]
 let main args =


### PR DESCRIPTION
This ensures that all tables are working in the default/supplied schema.
Before some where being migrated into a default schema, and some into
logary. Depending on the database this may work, but it definitely fails
on sql server.

Also adds a up/down test that works on a localhost SQL Server instance
to ensure that it still works.
This is commented to not break existing infrastructure

Should fix with #264