### PR TITLE
Present Log4J throwables as string

### DIFF
--- a/src/Logary.Tests/Codecs.fs
+++ b/src/Logary.Tests/Codecs.fs
@@ -104,22 +104,15 @@ method="run" file="Generator.java" line="94"/>
 
           m |> Message.tryGetField "log4japp"
             |> Expect.equal "Has log4japp-field" (Some "udp-generator")
-
-          let error: Formatting.StacktraceLine[] =
-            m |> Message.tryGetField "error"
-              |> Option.get
-
-          let expected =
-            "java.lang.Exception: someexception-third\n 	at org.apache.log4j.chainsaw.Generator.run(Generator.java:94)"
-            |> Formatting.DotNetStacktrace.parse
-
-          error
-            |> Expect.sequenceEqual "Should have the same stacktrace parsed" expected
-
-          m
-            |> Message.tryGetError
-            |> Option.get
-            |> Expect.sequenceEqual "Should have same stacktrace with tryGetError" expected
+          
+          m |> Message.tryGetField "error"
+            |> Expect.equal 
+                  "Should parse throwable correctly" 
+                  (
+                    Some "java.lang.Exception: someexception-third
+ 	at org.apache.log4j.chainsaw.Generator.run(Generator.java:94)
+"
+                  ) 
 
         | Result.Error err ->
           failtestf "%s" err

--- a/src/Logary/Codecs/Codecs.fs
+++ b/src/Logary/Codecs/Codecs.fs
@@ -127,12 +127,12 @@ module Codec =
           properties =
             let thread = event |> xattr "thread"
             let ndc = event |> xe ns "NDC" |> xtext
-            let throwable = event |> xe ns "throwable" |> xtext |> DotNetStacktrace.parse
+            let throwable = event |> xe ns "throwable" |> xtext
             (HashMap.empty, event |> xe ns "properties" |> xes "data")
             ||> Seq.fold foldProp
             |> if thread = "" then id else addLiteral "thread" thread
             |> if ndc = "" then id else addLiteral "NDC" ndc
-            |> if Array.isEmpty throwable then id else addLiteral "error" throwable
+            |> if String.IsNullOrEmpty throwable then id else addLiteral "error" throwable
         }
         |> Result.Ok
 


### PR DESCRIPTION
Previously, Log4J throwable were parsed into an array. This made it really hard to read stacktraces in Stackdriver - to read a stacktrace, you had to click twice for each line of the stacktrace.

This commit removes the stacktrace parsing and instead presents the throwable as a raw string

Before:
![before](https://user-images.githubusercontent.com/131192/40277250-052bcd0e-5c1c-11e8-8baf-518e959831f4.PNG)

After:
![after](https://user-images.githubusercontent.com/131192/40277255-0f71ceee-5c1c-11e8-82d6-277bf024e508.PNG)
