### PR TITLE
Fix KiB/Mib/Gib definitions in the File module

### DIFF
--- a/src/Logary.Tests/CoreTarget.fs
+++ b/src/Logary.Tests/CoreTarget.fs
@@ -215,6 +215,15 @@ module Files =
             acks.Add ack
           Job.conIgnore acks)
       }
+    
+    testList "quantities" [
+      testCase "1 KiB is 1024 B" <| fun _ ->
+        Expect.isTrue (KiB 1L = B 1024L) "1 KiB should be equal 1024 B"
+      testCase "1 MiB is 1024 KiB" <| fun _ ->
+        Expect.isTrue (MiB 1L = KiB 1024L) "1 MiB should be equal 1024 KiB"
+      testCase "1 GiB is 1024 MiB" <| fun _ ->
+        Expect.isTrue (GiB 1L = MiB 1024L) "1 GiB should be equal 1024 MiB"
+    ]
   ]
 
 let tests = [

--- a/src/Logary/Targets/Core.fs
+++ b/src/Logary/Targets/Core.fs
@@ -676,11 +676,11 @@ module File =
   /// Bytes
   let B (n: int64) = n
   /// Kilobytes
-  let KiB n = n * 1024L * 1024L
+  let KiB n = n * 1024L
   /// Megabytes
-  let MiB n = n * 1024L * 1024L * 1024L
+  let MiB n = n * 1024L * 1024L
   /// Gigabytes
-  let GiB n = n * 1024L * 1024L * 1024L * 1024L
+  let GiB n = n * 1024L * 1024L * 1024L
 
   /// These are the available rotation policies
   type RotationPolicy =


### PR DESCRIPTION
Fixing KiB/MiB/GiB definitions so that 1 KiB equals 1024 B, 1 MiB equals 1024 KiB, and 1 GiB equals 1024 MiB.